### PR TITLE
Can't use .circuitpython.skip, that's used to skip pylint.

### DIFF
--- a/get_imports.py
+++ b/get_imports.py
@@ -182,14 +182,14 @@ def get_learn_guide_cp_projects():
             continue
 
         # Skip this folder and all subfolders
-        if ".circuitpython.skip" in filenames:
+        if ".circuitpython.skip-screenshot" in filenames:
             del dirnames[:]
             continue
         # Skip files in this folder, but handle sub-folders
-        if ".circuitpython.skip-here" in filenames:
+        if ".circuitpython.skip-screenshot-here" in filenames:
             continue
         # Do not reurse, but handle files in this folder
-        if ".circuitpython.skip-sub" in filenames:
+        if ".circuitpython.skip-screenshot-sub" in filenames:
             del dirnames[:]
 
         if any(f for f in filenames if f.endswith(".py")):


### PR DESCRIPTION
Together with https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/1774 this restores screenshots for code samples that were skipped after https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/1772