### PR TITLE
include files in first level of subdirectories

### DIFF
--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -86,7 +86,6 @@ def generate_requirement_image(
 ):  # pylint: disable=too-many-statements
     """Generate a single requirement image"""
 
-
     def make_line(
         requirement_name, position=(0, 0), icon=None, hidden=False, triangle_icon=None
     ):  # pylint: disable=too-many-branches
@@ -161,7 +160,11 @@ def generate_requirement_image(
 
     def make_header(position, project_files):
         # Static files
-        make_line("CIRCUITPY", (position[0] + INDENT_SIZE, position[1]), triangle_icon=down_triangle)
+        make_line(
+            "CIRCUITPY",
+            (position[0] + INDENT_SIZE, position[1]),
+            triangle_icon=down_triangle,
+        )
         make_line(
             ".fseventsd",
             (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * 1)),
@@ -195,13 +198,14 @@ def generate_requirement_image(
         project_files_to_draw = []
         project_folders_to_draw = {}
         for cur_file in project_files:
-            if type(cur_file) == str:
+            # string for individual file
+            if isinstance(cur_file, str):
                 if "." in cur_file[-5:]:
                     cur_extension = cur_file.split(".")[-1]
                     if cur_extension in SHOWN_FILETYPES:
                         project_files_to_draw.append(cur_file)
-
-            elif type(cur_file) == tuple:
+            # tuple for directory
+            elif isinstance(cur_file, tuple):
                 project_folders_to_draw[cur_file[0]] = cur_file[1]
 
         for i, file in enumerate(sorted(project_files_to_draw)):
@@ -221,12 +225,15 @@ def generate_requirement_image(
                 file,
                 (
                     position[0] + INDENT_SIZE * 2,
-                    position[1] + (LINE_SPACING * (6 + i + len(project_files_to_draw) + extra_rows)),
+                    position[1]
+                    + (
+                        LINE_SPACING * (6 + i + len(project_files_to_draw) + extra_rows)
+                    ),
                 ),
                 triangle_icon=down_triangle,
             )
             rows_added += 1
-            for j, sub_file in enumerate(sorted(project_folders_to_draw[file])):
+            for sub_file in sorted(project_folders_to_draw[file]):
                 extra_rows += 1
                 cur_file_extension = sub_file.split(".")[-1]
                 cur_file_icon = FILE_TYPE_ICON_MAP.get(cur_file_extension, folder_icon)
@@ -236,13 +243,11 @@ def generate_requirement_image(
                 make_line(
                     sub_file,
                     (
-                        position[0] + INDENT_SIZE *3,
-                        #position[1] + (LINE_SPACING * (6 + i + j + 1 + extra_sub_file_space
-                        #                               + len(project_files_to_draw))),
+                        position[0] + INDENT_SIZE * 3,
                         position[1] + (LINE_SPACING * (6 + rows_added)),
                     ),
                     triangle_icon=triangle_icon,
-                    icon=cur_file_icon
+                    icon=cur_file_icon,
                 )
                 rows_added += 1
 
@@ -307,9 +312,12 @@ def generate_requirement_image(
     def count_files(files_list):
         _count = 0
         for _file in files_list:
-            if type(_file) == str:
+            # string for individual file
+            if isinstance(_file, str):
                 _count += 1
-            elif type(_file) == tuple:
+
+            # tuple for directory
+            elif isinstance(_file, tuple):
                 _count += 1
                 _count += len(_file[1])
         return _count

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -86,6 +86,7 @@ def generate_requirement_image(
 ):  # pylint: disable=too-many-statements
     """Generate a single requirement image"""
 
+
     def make_line(
         requirement_name, position=(0, 0), icon=None, hidden=False, triangle_icon=None
     ):  # pylint: disable=too-many-branches
@@ -192,14 +193,16 @@ def generate_requirement_image(
         # dynamic files from project dir in learn guide repo
         rows_added = 0
         project_files_to_draw = []
-        project_folders_to_draw = []
+        project_folders_to_draw = {}
         for cur_file in project_files:
-            if "." in cur_file[-5:]:
-                cur_extension = cur_file.split(".")[-1]
-                if cur_extension in SHOWN_FILETYPES:
-                    project_files_to_draw.append(cur_file)
-            else:
-                project_folders_to_draw.append(cur_file)
+            if type(cur_file) == str:
+                if "." in cur_file[-5:]:
+                    cur_extension = cur_file.split(".")[-1]
+                    if cur_extension in SHOWN_FILETYPES:
+                        project_files_to_draw.append(cur_file)
+
+            elif type(cur_file) == tuple:
+                project_folders_to_draw[cur_file[0]] = cur_file[1]
 
         for i, file in enumerate(sorted(project_files_to_draw)):
             cur_file_extension = file.split(".")[-1]
@@ -212,16 +215,41 @@ def generate_requirement_image(
             )
             rows_added += 1
 
-        for i, file in enumerate(sorted(project_folders_to_draw)):
+        extra_rows = 0
+        for i, file in enumerate(sorted(project_folders_to_draw.keys())):
             make_line(
                 file,
                 (
                     position[0] + INDENT_SIZE * 2,
-                    position[1] + (LINE_SPACING * (6 + i + len(project_files_to_draw))),
+                    position[1] + (LINE_SPACING * (6 + i + len(project_files_to_draw) + extra_rows)),
                 ),
-                triangle_icon=right_triangle,
+                triangle_icon=down_triangle,
             )
             rows_added += 1
+            if file == "midi":
+                #print(project_folders_to_draw)
+                pass
+            extra_sub_file_space = 0
+            for j, sub_file in enumerate(sorted(project_folders_to_draw[file])):
+                extra_rows += 1
+                cur_file_extension = sub_file.split(".")[-1]
+                cur_file_icon = FILE_TYPE_ICON_MAP.get(cur_file_extension, folder_icon)
+                triangle_icon = None
+                if cur_file_icon == folder_icon:
+                    triangle_icon = right_triangle
+                make_line(
+                    sub_file,
+                    (
+                        position[0] + INDENT_SIZE *3,
+                        #position[1] + (LINE_SPACING * (6 + i + j + 1 + extra_sub_file_space
+                        #                               + len(project_files_to_draw))),
+                        position[1] + (LINE_SPACING * (6 + rows_added)),
+                    ),
+                    triangle_icon=triangle_icon,
+                    icon=cur_file_icon
+                )
+                rows_added += 1
+            extra_sub_file_space = extra_rows
 
         make_line(
             "lib",
@@ -281,6 +309,16 @@ def generate_requirement_image(
         package_list, file_list = get_dependencies(libraries)
         return sorted(package_list) + sorted(file_list)
 
+    def count_files(files_list):
+        _count = 0
+        for _file in files_list:
+            if type(_file) == str:
+                _count += 1
+            elif type(_file) == tuple:
+                _count += 1
+                _count += len(_file[1])
+        return _count
+
     def make_libraries(libraries, position):
 
         for i, lib_name in enumerate(libraries):
@@ -301,7 +339,7 @@ def generate_requirement_image(
     if "main.py" in project_files:
         project_files.remove("main.py")
 
-    project_files_count = len(project_files)
+    project_files_count = count_files(project_files)
 
     image_height = (
         PADDING * 2

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -159,32 +159,32 @@ def generate_requirement_image(
 
     def make_header(position, project_files):
         # Static files
-        make_line("CIRCUITPY", position)
+        make_line("CIRCUITPY", (position[0] + INDENT_SIZE, position[1]), triangle_icon=down_triangle)
         make_line(
             ".fseventsd",
-            (position[0] + INDENT_SIZE, position[1] + (LINE_SPACING * 1)),
+            (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * 1)),
             hidden=True,
             triangle_icon=right_triangle,
         )
         make_line(
             ".metadata_never_index",
-            (position[0] + INDENT_SIZE, position[1] + (LINE_SPACING * 2)),
+            (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * 2)),
             icon=file_empty_hidden_icon,
             hidden=True,
         )
         make_line(
             ".Trashes",
-            (position[0] + INDENT_SIZE, position[1] + (LINE_SPACING * 3)),
+            (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * 3)),
             icon=file_empty_hidden_icon,
             hidden=True,
         )
         make_line(
             "boot_out.txt",
-            (position[0] + INDENT_SIZE, position[1] + (LINE_SPACING * 4)),
+            (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * 4)),
         )
         make_line(
             "code.py",
-            (position[0] + INDENT_SIZE, position[1] + (LINE_SPACING * 5)),
+            (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * 5)),
             icon=file_icon,
         )
 
@@ -206,7 +206,7 @@ def generate_requirement_image(
             cur_file_icon = FILE_TYPE_ICON_MAP.get(cur_file_extension, file_empty_icon)
             make_line(
                 file,
-                (position[0] + INDENT_SIZE, position[1] + (LINE_SPACING * (6 + i))),
+                (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * (6 + i))),
                 icon=cur_file_icon,
             )
             rows_added += 1
@@ -215,7 +215,7 @@ def generate_requirement_image(
             make_line(
                 file,
                 (
-                    position[0] + INDENT_SIZE,
+                    position[0] + INDENT_SIZE * 2,
                     position[1] + (LINE_SPACING * (6 + i + len(project_files_to_draw))),
                 ),
                 triangle_icon=right_triangle,
@@ -225,7 +225,7 @@ def generate_requirement_image(
         make_line(
             "lib",
             (
-                position[0] + INDENT_SIZE,
+                position[0] + INDENT_SIZE * 2,
                 position[1] + (LINE_SPACING * (5 + rows_added + 1)),
             ),
             triangle_icon=down_triangle,
@@ -288,7 +288,7 @@ def generate_requirement_image(
                 triangle_icon = right_triangle
             make_line(
                 lib_name,
-                (position[0] + INDENT_SIZE * 2, position[1] + (LINE_SPACING * i)),
+                (position[0] + INDENT_SIZE * 3, position[1] + (LINE_SPACING * i)),
                 triangle_icon=triangle_icon,
             )
 

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -226,10 +226,6 @@ def generate_requirement_image(
                 triangle_icon=down_triangle,
             )
             rows_added += 1
-            if file == "midi":
-                #print(project_folders_to_draw)
-                pass
-            extra_sub_file_space = 0
             for j, sub_file in enumerate(sorted(project_folders_to_draw[file])):
                 extra_rows += 1
                 cur_file_extension = sub_file.split(".")[-1]
@@ -249,7 +245,6 @@ def generate_requirement_image(
                     icon=cur_file_icon
                 )
                 rows_added += 1
-            extra_sub_file_space = extra_rows
 
         make_line(
             "lib",

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -36,7 +36,7 @@ ROW_COLOR = "#383838"
 TEXT_COLOR = "#B0B0B0"
 HIDDEN_TEXT_COLOR = "#808080"
 
-SHOWN_FILETYPES = ["py", "mpy", "bmp", "pcf", "bdf", "wav", "mp3", "json", "txt"]
+SHOWN_FILETYPES = ["py", "mpy", "bmp", "pcf", "bdf", "wav", "mp3", "mid", "json", "txt"]
 
 f = open("latest_bundle_data.json", "r")
 bundle_data = json.load(f)
@@ -70,6 +70,7 @@ FILE_TYPE_ICON_MAP = {
     "bmp": file_image_icon,
     "wav": file_music_icon,
     "mp3": file_music_icon,
+    "mid": file_music_icon,
     "pcf": file_font_icon,
     "bdf": file_font_icon,
     "json": file_icon,

--- a/get_imports.py
+++ b/get_imports.py
@@ -111,12 +111,9 @@ def get_files_for_project(project_name):
     """Get the set of files for a learn project"""
     found_files = set()
     project_dir = "{}/{}/".format(LEARN_GUIDE_REPO, project_name)
-    # root level
-    full_tree = os.walk(project_dir)
 
+    full_tree = os.walk(project_dir)
     root_level = next(full_tree)
-    if project_name == "NeoTrellis_M4_MIDI_Synth":
-        print(root_level)
 
     for file in root_level[2]:
         if "." in file:
@@ -126,19 +123,9 @@ def get_files_for_project(project_name):
                 found_files.add(file)
 
     for _dir in root_level[1]:
-        if project_name == "NeoTrellis_M4_MIDI_Synth":
-            print(_dir)
-        # TODO: second item needs to be a tuple
         dir_tuple = (_dir, tuple())
         for cur_tuple in os.walk(project_dir):
-            if project_name == "NeoTrellis_M4_MIDI_Synth":
-                print(cur_tuple)
-                #print("{} - {}".format(cur_tuple[0].split("/")[-1], _dir))
-                #print(cur_tuple)
             if cur_tuple[0].split("/")[-1] == _dir:
-                # TODO: can't use add or append to add to a tuple
-                # TODO: need to use + to make new tuple or * unpacking
-                # https://stackoverflow.com/questions/16730339/python-add-item-to-the-tuple
                 for _sub_dir in cur_tuple[1]:
                     dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_dir,))
                 for _sub_file in cur_tuple[2]:

--- a/get_imports.py
+++ b/get_imports.py
@@ -19,7 +19,7 @@ LEARN_GUIDE_REPO = os.environ.get(
     "LEARN_GUIDE_REPO", "../Adafruit_Learning_System_Guides/"
 )
 
-SHOWN_FILETYPES = ["py", "mpy", "bmp", "pcf", "bdf", "wav", "mp3", "json", "txt"]
+SHOWN_FILETYPES = ["py", "mpy", "bmp", "pcf", "bdf", "wav", "mp3", "mid", "json", "txt"]
 SHOWN_FILETYPES_EXAMPLE = [s for s in SHOWN_FILETYPES if s != "py"]
 
 

--- a/get_imports.py
+++ b/get_imports.py
@@ -111,15 +111,41 @@ def get_files_for_project(project_name):
     """Get the set of files for a learn project"""
     found_files = set()
     project_dir = "{}/{}/".format(LEARN_GUIDE_REPO, project_name)
-    for file in os.listdir(project_dir):
+    # root level
+    full_tree = os.walk(project_dir)
+
+    root_level = next(full_tree)
+    if project_name == "NeoTrellis_M4_MIDI_Synth":
+        print(root_level)
+
+    for file in root_level[2]:
         if "." in file:
             cur_extension = file.split(".")[-1]
             if cur_extension in SHOWN_FILETYPES:
                 # print(file)
                 found_files.add(file)
-        else:
-            # add dir
-            found_files.add(file)
+
+    for _dir in root_level[1]:
+        if project_name == "NeoTrellis_M4_MIDI_Synth":
+            print(_dir)
+        # TODO: second item needs to be a tuple
+        dir_tuple = (_dir, tuple())
+        for cur_tuple in os.walk(project_dir):
+            if project_name == "NeoTrellis_M4_MIDI_Synth":
+                print(cur_tuple)
+                #print("{} - {}".format(cur_tuple[0].split("/")[-1], _dir))
+                #print(cur_tuple)
+            if cur_tuple[0].split("/")[-1] == _dir:
+                # TODO: can't use add or append to add to a tuple
+                # TODO: need to use + to make new tuple or * unpacking
+                # https://stackoverflow.com/questions/16730339/python-add-item-to-the-tuple
+                for _sub_dir in cur_tuple[1]:
+                    dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_dir,))
+                for _sub_file in cur_tuple[2]:
+                    dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_file,))
+
+        # e.g. ("dir_name", ("file_1.txt", "file_2.txt"))
+        found_files.add(dir_tuple)
     return found_files
 
 


### PR DESCRIPTION
This adds the triangle icon to the top level CIRCUITPY and indents all files beneath it one level to make it more clear that they are inside of CIRCUITPY

Also it will now include the files that are inside of the first level of sub-directories showing them as open / "unfolded" with the files inside drawn below and indented.

Here is an example of the output: 
![NeoTrellis_M4_MIDI_Synth](https://user-images.githubusercontent.com/2406189/129480671-6029e2a3-21c5-4998-b547-bd718cd96241.png)

Here is the screenshot for the same library produced by the previous version: 
![image](https://user-images.githubusercontent.com/2406189/129480702-52e17055-2c95-4d70-9be7-cc5bdf1fe930.png)

