### PR TITLE
fix image for library examples that contain directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ __pycache__
 latest_bundle_data.json
 latest_bundle_tag.json
 generated_images
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 latest_bundle_data.json
 latest_bundle_tag.json
 generated_images
+.idea

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -74,6 +74,7 @@ FILE_TYPE_ICON_MAP = {
     "pcf": file_font_icon,
     "bdf": file_font_icon,
     "json": file_icon,
+    "license": file_empty_icon,
 }
 
 # If this is not done, the images fail to load in the subprocesses.

--- a/get_imports.py
+++ b/get_imports.py
@@ -158,15 +158,30 @@ def get_files_for_example(example_path):
     """Get the set of files for a library example"""
     found_files = set(("code.py",))
     example_dir = os.path.dirname(example_path)
-    for file in os.listdir(example_dir):
+
+    full_tree = os.walk(example_dir)
+    root_level = next(full_tree)
+
+    for file in root_level[2]:
         if "." in file:
             cur_extension = file.split(".")[-1]
             if cur_extension in SHOWN_FILETYPES_EXAMPLE:
                 # print(file)
                 found_files.add(file)
-        else:
-            # add dir
-            found_files.add(file)
+
+    for _dir in root_level[1]:
+        dir_tuple = (_dir, tuple())
+        for cur_tuple in os.walk(example_dir):
+            if cur_tuple[0].split("/")[-1] == _dir:
+                for _sub_dir in cur_tuple[1]:
+                    dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_dir,))
+                for _sub_file in cur_tuple[2]:
+                    dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_file,))
+
+        # e.g. ("dir_name", ("file_1.txt", "file_2.txt"))
+
+        if ".circuitpython.skip-screenshot" not in dir_tuple[1]:
+            found_files.add(dir_tuple)
     return found_files
 
 
@@ -201,7 +216,7 @@ def get_learn_guide_cp_projects():
         # Skip files in this folder, but handle sub-folders
         if ".circuitpython.skip-screenshot-here" in filenames:
             continue
-        # Do not reurse, but handle files in this folder
+        # Do not recurse, but handle files in this folder
         if ".circuitpython.skip-screenshot-sub" in filenames:
             del dirnames[:]
 


### PR DESCRIPTION
resolves: #9 

This change fixes the images that get generated of library example folders if they contain directories. 

Previously there was a bug causing the directory not to get shown, but still having an empty line worth of space created for it.

The new version will include directories and thier contents as long as the directory does not contain the `.circuitpython.skip-screenshot` file. After this gets merged we'll need to add that file into any examples subdirectories that we don't want included in the screenshots e.g. `advanced_examples` directory in the circuitplayground and CLUE libraries does not need to be shown in the images for any of the other examples.

Here are some of the images that the updated scripts generated:

Circuitplayground example that the problem was originall reported on (I manually included the `.circuitpython-skip-screenshot` file to generate this):
![image](https://user-images.githubusercontent.com/2406189/141653426-57e924ff-d7b0-4613-b6d9-5f4cbd745ae8.png)

CLUE library example that suffered from the same bug also due to `advanced_examples` (I manually included the `.circuitpython-skip-screenshot` file to generate this):
![image](https://user-images.githubusercontent.com/2406189/141653450-d344aed9-08a6-462c-ac13-9a87146090c8.png)

Bitmap font example that also suffered from this issue, but does need to show it's sub-directory which contains files necessary to run the examples:
![image](https://user-images.githubusercontent.com/2406189/141653478-0b485a0b-c9a2-4c5a-adef-2efe271325a3.png)
