### PR TITLE
skip file for subdirectories in learn guides

### DIFF
--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -206,7 +206,8 @@ def generate_requirement_image(
                         project_files_to_draw.append(cur_file)
             # tuple for directory
             elif isinstance(cur_file, tuple):
-                project_folders_to_draw[cur_file[0]] = cur_file[1]
+                if ".circuitpython.skip-screenshot" not in cur_file[1]:
+                    project_folders_to_draw[cur_file[0]] = cur_file[1]
 
         for i, file in enumerate(sorted(project_files_to_draw)):
             cur_file_extension = file.split(".")[-1]
@@ -318,8 +319,9 @@ def generate_requirement_image(
 
             # tuple for directory
             elif isinstance(_file, tuple):
-                _count += 1
-                _count += len(_file[1])
+                if ".circuitpython.skip-screenshot" not in _file[1]:
+                    _count += 1
+                    _count += len(_file[1])
         return _count
 
     def make_libraries(libraries, position):


### PR DESCRIPTION
This change will make the tool skip subdirectories that contain the `.circuitpython.skip-screenshot` file.

Screenshots previously would come out like this:
![image](https://user-images.githubusercontent.com/2406189/153785502-993af319-3da7-46d3-b697-24b6cc06450c.png)

after these changes the sub-directory is skipped as intended.
![image](https://user-images.githubusercontent.com/2406189/153785527-5e01c00a-3395-43b5-a590-1449094b913d.png)

Note that the top screenshot does show the incorrect filename for the skip file. The code uses `.circuitpython.skip-screenshot` which was already in use elsewhere and seems appropriately named for this. 