### PR TITLE
adding support CSV file type in screenshots

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.x
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - uses: pre-commit/action@v2.0.2

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,5 +13,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
     - uses: pre-commit/action@v2.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -14,6 +14,7 @@ import os
 
 import click
 from PIL import Image, ImageDraw, ImageFont
+from get_imports import SHOWN_FILETYPES
 
 from get_imports import (
     get_libs_for_project,
@@ -35,8 +36,6 @@ ROW_COLOR = "#383838"
 
 TEXT_COLOR = "#B0B0B0"
 HIDDEN_TEXT_COLOR = "#808080"
-
-SHOWN_FILETYPES = ["py", "mpy", "bmp", "pcf", "bdf", "wav", "mp3", "mid", "json", "txt"]
 
 f = open("latest_bundle_data.json", "r")
 bundle_data = json.load(f)
@@ -73,6 +72,7 @@ FILE_TYPE_ICON_MAP = {
     "mid": file_music_icon,
     "pcf": file_font_icon,
     "bdf": file_font_icon,
+    "csv": file_empty_icon,
     "json": file_icon,
     "license": file_empty_icon,
 }
@@ -203,6 +203,9 @@ def generate_requirement_image(
             if isinstance(cur_file, str):
                 if "." in cur_file[-5:]:
                     cur_extension = cur_file.split(".")[-1]
+                    if cur_extension == "csv":
+                        print("Found CSV:")
+                        print(cur_file)
                     if cur_extension in SHOWN_FILETYPES:
                         project_files_to_draw.append(cur_file)
             # tuple for directory

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -203,9 +203,6 @@ def generate_requirement_image(
             if isinstance(cur_file, str):
                 if "." in cur_file[-5:]:
                     cur_extension = cur_file.split(".")[-1]
-                    if cur_extension == "csv":
-                        print("Found CSV:")
-                        print(cur_file)
                     if cur_extension in SHOWN_FILETYPES:
                         project_files_to_draw.append(cur_file)
             # tuple for directory

--- a/get_imports.py
+++ b/get_imports.py
@@ -12,6 +12,7 @@ import os
 import findimports
 import requests
 
+
 BUNDLE_DATA = "latest_bundle_data.json"
 BUNDLE_TAG = "latest_bundle_tag.json"
 
@@ -19,7 +20,19 @@ LEARN_GUIDE_REPO = os.environ.get(
     "LEARN_GUIDE_REPO", "../Adafruit_Learning_System_Guides/"
 )
 
-SHOWN_FILETYPES = ["py", "mpy", "bmp", "pcf", "bdf", "wav", "mp3", "mid", "json", "txt"]
+SHOWN_FILETYPES = [
+    "py",
+    "mpy",
+    "bmp",
+    "pcf",
+    "bdf",
+    "wav",
+    "mp3",
+    "mid",
+    "json",
+    "txt",
+    "csv",
+]
 SHOWN_FILETYPES_EXAMPLE = [s for s in SHOWN_FILETYPES if s != "py"]
 
 


### PR DESCRIPTION
ping @kattni.

This should allow .csv files in the learn guide project or library repo to be included in the screenshots that are generated. 

Here is an example of the new version of the screenshot for one of the learn projects (literary-clock) that has a CSV file:

Before:
![image](https://user-images.githubusercontent.com/2406189/200083577-df03d15c-4fed-45f7-8a29-a0956f6ed69b.png)

After:
![image](https://user-images.githubusercontent.com/2406189/200083290-f4cb485d-2e5a-4d2a-b8af-961890b90ebc.png)
