### PR TITLE
add settings.toml to the rendered screenshots if needed. 

### DIFF
--- a/settings_required.py
+++ b/settings_required.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2023 Tim C
+# SPDX-License-Identifier: MIT
+
+"""
+Utility function to check whether settings.toml file should be rendered for a project.
+Based on whether it uses certain libraries or not.
+"""
+
+
+LIBRARIES_THAT_REQUIRE_SETTINGS = [
+    "adafruit_requests.mpy",
+    "adafruit_esp32spi",
+    "adafruit_minimqtt",
+    "adafruit_portalbase",
+    "adafruit_azureiot",
+]
+
+
+def settings_required(files_and_libs):
+    """
+    Returns True if the project needs ot have a settings.toml file
+
+    :param files_and_libs list: a List of all files and libraries used in the project
+    """
+
+    if "settings.toml" in files_and_libs:
+        # settings.toml file is already in the files so we don't need to add it again
+        return False
+
+    # if any of the libraries that require settings.toml are included in this project
+    if any(
+        libs_that_require_settings in files_and_libs
+        for libs_that_require_settings in LIBRARIES_THAT_REQUIRE_SETTINGS
+    ):
+        return True
+
+    return False


### PR DESCRIPTION
Also fixed a bug with code file icon showing empty file for some files that should have been the code icon.

Whether to render settings.toml or not is determined by whether any of a certain list of libraries are used by the project. The current list is:
```
LIBRARIES_THAT_REQUIRE_SETTINGS = [
    "adafruit_requests.mpy",
    "adafruit_esp32spi",
    "adafruit_minimqtt",
    "adafruit_portalbase",
    "adafruit_azureiot",
]
```

Here's one example of the new screenshot with settings.toml included
![MagTag_Quote_Board](https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker/assets/2406189/2f55ec37-c6aa-4e0f-9c43-6656d50cf1d2)


If the project doesn't have one of the specified libraries used it will render the same as it would have previously. Here is one without settings.toml:

![AutoSunglasses](https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker/assets/2406189/bfadf641-c20d-496d-891a-2357b3a13322)
