### PR TITLE
fix duplicate lib dirs + update actions environment

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
+    - run: python3 -m venv build_images_venv
+    - run: source build_images_venv/bin/activate
     - run: python3 -mpip install -r requirements.txt
     - run: git clone --depth=1 https://github.com/adafruit/Adafruit_Learning_System_Guides learn
     - run: env LEARN_GUIDE_REPO=learn/ python3 create_requirement_images.py

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - run: python3 -mpip install -r requirements.txt

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -14,7 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: python3 -m venv build_images_venv
-    - run: source build_images_venv/bin/activate
+    - name: Activate virtualenv
+      run: |
+        . .build_images_venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
     - run: python3 -mpip install -r requirements.txt
     - run: git clone --depth=1 https://github.com/adafruit/Adafruit_Learning_System_Guides learn
     - run: env LEARN_GUIDE_REPO=learn/ python3 create_requirement_images.py

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,7 +16,7 @@ jobs:
     - run: python3 -m venv build_images_venv
     - name: Activate virtualenv
       run: |
-        . .build_images_venv/bin/activate
+        . build_images_venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
     - run: python3 -mpip install -r requirements.txt
     - run: git clone --depth=1 https://github.com/adafruit/Adafruit_Learning_System_Guides learn

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,7 +20,7 @@ jobs:
         echo PATH=$PATH >> $GITHUB_ENV
     - run: python3 -mpip install -r requirements.txt
     - run: git clone --depth=1 https://github.com/adafruit/Adafruit_Learning_System_Guides learn
-    - run: env LEARN_GUIDE_REPO=learn/ python3 create_requirement_images.py learn
+    - run: env LEARN_GUIDE_REPO=learn/ python3 create_requirement_images.py
     - uses: actions/upload-artifact@v4
       with:
         name: images

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,7 +20,7 @@ jobs:
         echo PATH=$PATH >> $GITHUB_ENV
     - run: python3 -mpip install -r requirements.txt
     - run: git clone --depth=1 https://github.com/adafruit/Adafruit_Learning_System_Guides learn
-    - run: env LEARN_GUIDE_REPO=learn/ python3 create_requirement_images.py
+    - run: env LEARN_GUIDE_REPO=learn/ python3 create_requirement_images.py learn
     - uses: actions/upload-artifact@v4
       with:
         name: images

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 __pycache__
 latest_bundle_data.json
 latest_bundle_tag.json
+latest_community_bundle_data.json
+latest_community_bundle_tag.json
 generated_images
 
 # Virtual environment-specific files

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -316,9 +316,9 @@ def generate_requirement_image(
             lib_name = libraries_to_check[0]
             del libraries_to_check[0]
 
-            try:
+            if lib_name in bundle_data:
                 lib_obj = bundle_data[lib_name]
-            except KeyError:
+            else:
                 # Library isn't in bundle, so we don't know about its
                 # dependencies.
                 if "." in lib_name:

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -393,7 +393,7 @@ def generate_requirement_image(
         which will in turn get included in the libraries list that the
         tool uses to generate the "main" lib folder in the screenshot.
         """
-        _custom_libs = None
+        _custom_libs = tuple()
         remove_files = []
         for file in project_file_set:
             if not isinstance(file, tuple):


### PR DESCRIPTION
resolves: #15

If the `lib` directory exists in `project_files` it will be removed from there, and it's contents will be added to `libs` so that they get sorted and rendered into the final screenshot in the remaining `lib` directory along with all of the dependencies that were found from the bundle

`get_dependencies()` now handles gracefully libraries that aren't in the bundle and thus we don't know about their dependencies. They are added to the list as-is without any dependency information.

~~I'm pretty sure this PR will be failing actions. It needs some of the infrastructure updates from #21 in order to successfully pass I think. But I omitted them from this PR in order to keep it more contained to a single change and to not duplicate changes across multiple PRs.  After #21  is merged I'll come back and re-run the actions and fix anything still causing it to fail.~~