### PR TITLE
Include community bundle libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 __pycache__
 latest_bundle_data.json
 latest_bundle_tag.json
+latest_community_bundle_data.json
+latest_community_bundle_tag.json
 generated_images
 
 # Virtual environment-specific files

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -41,9 +41,8 @@ HIDDEN_TEXT_COLOR = "#808080"
 with open("latest_bundle_data.json", "r", encoding="utf-8") as f:
     bundle_data = json.load(f)
 
-f = open("latest_community_bundle_data.json", "r")
-community_bundle_data = json.load(f)
-f.close()
+with open("latest_community_bundle_data.json", "r", encoding="utf-8") as f:
+    community_bundle_data = json.load(f)
 
 
 def asset_path(asset_name):

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -42,6 +42,10 @@ f = open("latest_bundle_data.json", "r")
 bundle_data = json.load(f)
 f.close()
 
+f = open("latest_community_bundle_data.json", "r")
+community_bundle_data = json.load(f)
+f.close()
+
 
 def asset_path(asset_name):
     """Return the location of a file shipped with the screenshot maker"""
@@ -317,10 +321,23 @@ def generate_requirement_image(
             lib_name = libraries_to_check[0]
             del libraries_to_check[0]
 
-            lib_obj = bundle_data[lib_name]
+            if lib_name in bundle_data:
+                lib_obj = bundle_data[lib_name]
+                bundle_used = bundle_data
+            elif lib_name in community_bundle_data:
+                lib_obj = community_bundle_data[lib_name]
+                bundle_used = community_bundle_data
+            else:
+                # handle lib that is not in any known bundle
+                if "." in lib_name:
+                    file_list.add(lib_name)
+                else:
+                    package_list.add(lib_name)
+                continue
+
             for dep_name in lib_obj["dependencies"]:
                 libraries_to_check.append(dep_name)
-                dep_obj = bundle_data[dep_name]
+                dep_obj = bundle_used[dep_name]
                 if dep_obj["package"]:
                     package_list.add(dep_name)
                 else:

--- a/get_imports.py
+++ b/get_imports.py
@@ -19,8 +19,8 @@ ADAFRUIT_BUNDLE_TAG = "latest_bundle_tag.json"
 COMMUNITY_BUNDLE_DATA = "latest_community_bundle_data.json"
 COMMUNITY_BUNDLE_TAG = "latest_community_bundle_tag.json"
 
-ADAFRUIT_BUNDLE_S3_URL = "https://adafruit-circuit-python.s3.amazonaws.com/bundles/adafruit/adafruit-circuitpython-bundle-{tag}.json"
-COMMUNITY_BUNDLE_S3_URL = "https://adafruit-circuit-python.s3.amazonaws.com/bundles/community/circuitpython-community-bundle-{tag}.json"
+ADAFRUIT_BUNDLE_S3_URL = "https://adafruit-circuit-python.s3.amazonaws.com/bundles/adafruit/adafruit-circuitpython-bundle-{tag}.json"  # pylint: disable=line-too-long
+COMMUNITY_BUNDLE_S3_URL = "https://adafruit-circuit-python.s3.amazonaws.com/bundles/community/circuitpython-community-bundle-{tag}.json"  # pylint: disable=line-too-long
 
 LEARN_GUIDE_REPO = os.environ.get(
     "LEARN_GUIDE_REPO", "../Adafruit_Learning_System_Guides/"
@@ -44,7 +44,6 @@ SHOWN_FILETYPES_EXAMPLE = [s for s in SHOWN_FILETYPES if s != "py"]
 
 def get_bundle(bundle_url, bundle_data_file):
     """Download the Adafruit and Community bundles data"""
-    #url = f"https://adafruit-circuit-python.s3.amazonaws.com/bundles/adafruit/adafruit-circuitpython-bundle-{tag}.json"  # pylint: disable=line-too-long
     print(f"get bundle metadata from {bundle_url}")
     r = requests.get(bundle_url)
     with open(bundle_data_file, "wb") as bundle_file:
@@ -113,17 +112,23 @@ def ensure_latest_bundle(bundle_url, bundle_s3_url, bundle_tag_file, bundle_data
         print(f"Current library bundle up to date {tag}")
 
 
-ensure_latest_bundle("https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest",
-                     ADAFRUIT_BUNDLE_S3_URL,
-                     ADAFRUIT_BUNDLE_TAG, ADAFRUIT_BUNDLE_DATA)
-ensure_latest_bundle("https://github.com/adafruit/CircuitPython_Community_Bundle/releases/latest",
-                     COMMUNITY_BUNDLE_S3_URL,
-                     COMMUNITY_BUNDLE_TAG, COMMUNITY_BUNDLE_DATA)
+ensure_latest_bundle(
+    "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest",
+    ADAFRUIT_BUNDLE_S3_URL,
+    ADAFRUIT_BUNDLE_TAG,
+    ADAFRUIT_BUNDLE_DATA,
+)
+ensure_latest_bundle(
+    "https://github.com/adafruit/CircuitPython_Community_Bundle/releases/latest",
+    COMMUNITY_BUNDLE_S3_URL,
+    COMMUNITY_BUNDLE_TAG,
+    COMMUNITY_BUNDLE_DATA,
+)
 
 with open(ADAFRUIT_BUNDLE_DATA, "r", encoding="utf-8") as f:
     bundle_data = json.load(f)
 
-with open(COMMUNITY_BUNDLE_DATA, "r") as f:
+with open(COMMUNITY_BUNDLE_DATA, "r", encoding="utf-8") as f:
     community_bundle_data = json.load(f)
 
 


### PR DESCRIPTION
resolves: #20 

This pr does the following:

Updates the bundle version checking and fetching functionality to accept parameters indicating which bundle to work on instead of hardcoded to Adafruit bundle. 

Checks version and fetches community bundle in addition to Adafruit bundle. 

Includes community bundle libraries in the screenshot.

Preserves necessary fallback behavior from #22 to allow project specific custom libs which aren't in any bundle to be included in the screenshot

Removes the global var `LATEST_BUNDLE_VERSION` and it's usage.
