### PR TITLE
Fold directories to hide contents if they have too many files

### DIFF
--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -163,7 +163,7 @@ def generate_requirement_image(
             )
 
     def make_header(position, project_files, files_and_libs):
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals, too-many-branches
         # Static files
         make_line(
             "CIRCUITPY",
@@ -198,8 +198,7 @@ def generate_requirement_image(
             icon=file_icon,
         )
 
-        # TODO: Add settings.toml if it's needed
-
+        # Add settings.toml if it's needed
         if settings_required(files_and_libs):
             make_line(
                 "settings.toml",
@@ -247,6 +246,10 @@ def generate_requirement_image(
 
         extra_rows = 0
         for i, file in enumerate(sorted(project_folders_to_draw.keys())):
+            if len(project_folders_to_draw[file]) > 0:
+                triangle_to_use = down_triangle
+            else:
+                triangle_to_use = right_triangle
             make_line(
                 file,
                 (
@@ -257,7 +260,7 @@ def generate_requirement_image(
                         * (begin_y_offset + i + len(project_files_to_draw) + extra_rows)
                     ),
                 ),
-                triangle_icon=down_triangle,
+                triangle_icon=triangle_to_use,
             )
             rows_added += 1
             for sub_file in sorted(project_folders_to_draw[file]):

--- a/get_imports.py
+++ b/get_imports.py
@@ -16,6 +16,8 @@ import requests
 BUNDLE_DATA = "latest_bundle_data.json"
 BUNDLE_TAG = "latest_bundle_tag.json"
 
+SUBDIRECTORY_FILECOUNT_LIMIT = 10
+
 LEARN_GUIDE_REPO = os.environ.get(
     "LEARN_GUIDE_REPO", "../Adafruit_Learning_System_Guides/"
 )
@@ -141,8 +143,9 @@ def get_files_for_project(project_name):
             if cur_tuple[0].split("/")[-1] == _dir:
                 for _sub_dir in cur_tuple[1]:
                     dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_dir,))
-                for _sub_file in cur_tuple[2]:
-                    dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_file,))
+                if len(cur_tuple[2]) < SUBDIRECTORY_FILECOUNT_LIMIT:
+                    for _sub_file in cur_tuple[2]:
+                        dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_file,))
 
         # e.g. ("dir_name", ("file_1.txt", "file_2.txt"))
         found_files.add(dir_tuple)


### PR DESCRIPTION
Resolves: #12 

The project noted in the issue now gets this screenshot generated: 
![Matrix_Portal_Moon_Clock](https://github.com/user-attachments/assets/3c8b441c-0ff9-48b0-9c21-a0439d4d6b39)

I chose somewhat arbitrarily a limit of 10, but it's a variable and easy to change. I'm open to any feedback regarding the value to use as the cutoff.

Folder contents from folders that contain more than the cutoff amount of files are now omitted from the final list that get rendered. Folders rendered without any contents are shown with the folded triangle icon.