### PR TITLE
PNG file icon. Find libraries one level deeper from wildcard

### DIFF
--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -71,6 +71,7 @@ FILE_TYPE_ICON_MAP = {
     "txt": file_empty_icon,
     "toml": file_icon,
     "bmp": file_image_icon,
+    "png": file_image_icon,
     "wav": file_music_icon,
     "mp3": file_music_icon,
     "mid": file_music_icon,

--- a/get_imports.py
+++ b/get_imports.py
@@ -179,7 +179,7 @@ def get_libs_for_project(project_name):
                 if cur_lib in bundle_data or cur_lib in community_bundle_data:
                     found_libs.add(cur_lib)
 
-                # findimports returns import name in the form of ``foo.bar.*``
+                # findimports returns import name in the form of "foo.bar.*"
                 if cur_import.name.endswith(".*"):
                     filepath = os.path.join(
                         project_dir,

--- a/get_imports.py
+++ b/get_imports.py
@@ -179,8 +179,7 @@ def get_libs_for_project(project_name):
                 if cur_lib in bundle_data or cur_lib in community_bundle_data:
                     found_libs.add(cur_lib)
 
-                # check if it's a wildcard import e.g.
-                # from module.submodule import *
+                # findimports returns import name in the form of ``foo.bar.*``
                 if cur_import.name.endswith(".*"):
                     filepath = os.path.join(
                         project_dir,

--- a/get_imports.py
+++ b/get_imports.py
@@ -165,6 +165,7 @@ def get_files_for_project(project_name):
 
 
 def get_libs_for_project(project_name):
+    # pylint: disable=too-many-nested-blocks
     """Get the set of libraries for a learn project"""
     found_libs = set()
     found_imports = []
@@ -173,11 +174,23 @@ def get_libs_for_project(project_name):
         if file.endswith(".py"):
 
             found_imports = findimports.find_imports(f"{project_dir}{file}")
-
             for cur_import in found_imports:
                 cur_lib = cur_import.name.split(".")[0]
                 if cur_lib in bundle_data or cur_lib in community_bundle_data:
                     found_libs.add(cur_lib)
+                if cur_import.name.endswith(".*"):
+                    filepath = os.path.join(
+                        project_dir, "/".join(cur_import.name[:-2].split(".")) + ".py"
+                    )
+                    if os.path.exists(filepath):
+                        second_level_imports = findimports.find_imports(filepath)
+                        for cur_second_level_import in second_level_imports:
+                            cur_lib = cur_second_level_import.name.split(".")[0]
+                            if (
+                                cur_lib in bundle_data
+                                or cur_lib in community_bundle_data
+                            ):
+                                found_libs.add(cur_lib)
 
     return found_libs
 

--- a/get_imports.py
+++ b/get_imports.py
@@ -180,7 +180,8 @@ def get_libs_for_project(project_name):
                     found_libs.add(cur_lib)
                 if cur_import.name.endswith(".*"):
                     filepath = os.path.join(
-                        project_dir, "/".join(cur_import.name[:-2].split(".")) + ".py"
+                        project_dir,
+                        os.path.join(*cur_import.name[:-2].split(".")) + ".py",
                     )
                     if os.path.exists(filepath):
                         second_level_imports = findimports.find_imports(filepath)

--- a/get_imports.py
+++ b/get_imports.py
@@ -178,6 +178,9 @@ def get_libs_for_project(project_name):
                 cur_lib = cur_import.name.split(".")[0]
                 if cur_lib in bundle_data or cur_lib in community_bundle_data:
                     found_libs.add(cur_lib)
+
+                # check if it's a wildcard import e.g.
+                # from module.submodule import *
                 if cur_import.name.endswith(".*"):
                     filepath = os.path.join(
                         project_dir,


### PR DESCRIPTION
Resolves: #25 

Adds `.png` to the types that will get the image file icon.

Also checks for imports one level deeper inside of wildcard imports of files that are included in learn project code.

This allows Karel the Robot project to correctly show the required libraries inside of `lib/` even though they come from `karel.circuitpythonkarel.*` instead of `code.py` directly. 

With this change:
![image](https://github.com/user-attachments/assets/4f354689-623f-41c8-841b-69437ab48217)

With the current version:
![image](https://github.com/user-attachments/assets/f7c341e6-5159-4451-8dc2-35e16a492993)

