### PR TITLE
add connection_manager to settings.toml inclusions

### DIFF
--- a/settings_required.py
+++ b/settings_required.py
@@ -13,6 +13,7 @@ LIBRARIES_THAT_REQUIRE_SETTINGS = [
     "adafruit_minimqtt",
     "adafruit_portalbase",
     "adafruit_azureiot",
+    "adafruit_connection_manager",
 ]
 
 


### PR DESCRIPTION
This change will include `settings.toml` into the screenshot if `adafruit_connection_manager` is one of the libraries in use. 