### PR TITLE
fix connection_manager with .mpy extension. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ python3 create_requirement_images.py learn --guide [Learn Guide Name]
 python3 create_requirement_images.py learn -g [Learn Guide Name]
 ```
 
+### Generate Single Library Bundle Example Image
+```shell
+python3 create_requirement_images.py bundle [path to example].py
+# e.g.
+python3 create_requirement_images.py bundle Adafruit_CircuitPythonBundle/libraries/helpers/wiz/wiz_buttons_controller.py
+```
+
 ### Help Command
 The help command will list all possible commands and arguments.
 

--- a/settings_required.py
+++ b/settings_required.py
@@ -13,7 +13,7 @@ LIBRARIES_THAT_REQUIRE_SETTINGS = [
     "adafruit_minimqtt",
     "adafruit_portalbase",
     "adafruit_azureiot",
-    "adafruit_connection_manager",
+    "adafruit_connection_manager.mpy",
 ]
 
 


### PR DESCRIPTION
Also added section to readme about generating single example image to make testing easier in the future.

I confirmed that the `settings.toml` is correctly included with this change:
![image](https://github.com/user-attachments/assets/2768cc57-0fff-4fdd-921d-807b43902e3b)
