### PR TITLE
filter example subdir files by shown type

### DIFF
--- a/get_imports.py
+++ b/get_imports.py
@@ -220,11 +220,15 @@ def get_files_for_example(example_path):
                 for _sub_dir in cur_tuple[1]:
                     dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_dir,))
                 for _sub_file in cur_tuple[2]:
-                    dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_file,))
+                    if _sub_file.split(".")[-1] in SHOWN_FILETYPES_EXAMPLE:
+                        dir_tuple = (dir_tuple[0], dir_tuple[1] + (_sub_file,))
 
         # e.g. ("dir_name", ("file_1.txt", "file_2.txt"))
 
-        if ".circuitpython.skip-screenshot" not in dir_tuple[1]:
+        if (
+            ".circuitpython.skip-screenshot" not in dir_tuple[1]
+            and len(dir_tuple[1]) > 0
+        ):
             found_files.add(dir_tuple)
     return found_files
 


### PR DESCRIPTION
and omit directories if there are no shown filetypes inside of them.

It was reported that `.md` files were being included erroneously i.e. 
![image](https://github.com/user-attachments/assets/0388ece9-9bc8-431a-b1d0-37ea284a087a)


It turns out the filtering was occuring only on files in the root dir, not ones found in sub-directories. This change implements filtering on shown filetypes for files in subdirectories which in this case causes both `gpio.md` and `esp32spi_gpio.py` to filtered out and therefore the `gpio/` to be omitted. 

![image](https://github.com/user-attachments/assets/51ba78c8-bb5e-4adb-82bc-98a3e22a43ce)
