### PR TITLE
update the list of shown filetypes. always show settings.toml

### DIFF
--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -72,6 +72,7 @@ FILE_TYPE_ICON_MAP = {
     "toml": file_icon,
     "bmp": file_image_icon,
     "png": file_image_icon,
+    "jpg": file_image_icon,
     "wav": file_music_icon,
     "mp3": file_music_icon,
     "mid": file_music_icon,

--- a/get_imports.py
+++ b/get_imports.py
@@ -31,15 +31,19 @@ LEARN_GUIDE_REPO = os.environ.get(
 SHOWN_FILETYPES = [
     "py",
     "mpy",
+    "txt",
+    "toml",
     "bmp",
-    "pcf",
-    "bdf",
+    "png",
+    "jpg",
     "wav",
     "mp3",
     "mid",
-    "json",
-    "txt",
+    "pcf",
+    "bdf",
     "csv",
+    "json",
+    "license",
 ]
 SHOWN_FILETYPES_EXAMPLE = [s for s in SHOWN_FILETYPES if s != "py"]
 

--- a/settings_required.py
+++ b/settings_required.py
@@ -7,16 +7,6 @@ Based on whether it uses certain libraries or not.
 """
 
 
-LIBRARIES_THAT_REQUIRE_SETTINGS = [
-    "adafruit_requests.mpy",
-    "adafruit_esp32spi",
-    "adafruit_minimqtt",
-    "adafruit_portalbase",
-    "adafruit_azureiot",
-    "adafruit_connection_manager.mpy",
-]
-
-
 def settings_required(files_and_libs):
     """
     Returns True if the project needs ot have a settings.toml file
@@ -28,11 +18,6 @@ def settings_required(files_and_libs):
         # settings.toml file is already in the files so we don't need to add it again
         return False
 
-    # if any of the libraries that require settings.toml are included in this project
-    if any(
-        libs_that_require_settings in files_and_libs
-        for libs_that_require_settings in LIBRARIES_THAT_REQUIRE_SETTINGS
-    ):
-        return True
-
-    return False
+    # always show settings.toml because it is created by default when
+    # circuitpython is loaded, and when storage.erase_filesystem() is called
+    return True


### PR DESCRIPTION
Resolves: #31 
Updates the list of shown filetypes to match all of the ones in the Icon map. 

Also remove the restriction from showing `settings.toml`. With this change it will always be shown instead of only when certain libraries are present. 

I found that an empty settings.toml is created by default when Circuitpython is first loaded on a device, and when `storage.erase_filesystem()` is run so it's likely the user will see it on their drive no matter what libraries are in use. 

Removing the condition means we don't need to keep track of that list of libraries any more either :tada: 