### PR TITLE
show .md files in screenshot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v3.0.1
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -69,6 +69,7 @@ FILE_TYPE_ICON_MAP = {
     "py": file_icon,
     "mpy": file_icon,
     "txt": file_empty_icon,
+    "md": file_empty_icon,
     "toml": file_icon,
     "html": file_icon,
     "bmp": file_image_icon,

--- a/get_imports.py
+++ b/get_imports.py
@@ -32,6 +32,7 @@ SHOWN_FILETYPES = [
     "py",
     "mpy",
     "txt",
+    "md",
     "toml",
     "html",
     "bmp",


### PR DESCRIPTION
Added .md files to those shown in the screenshot.

Used for Tiny Wiki Learn guide in the works.

Current version without .md file: https://github.com/adafruit/Adafruit_Learning_System_Guides/blob/folder-images/Fruit_Jam_Fruit_Jam_Tiny_Wiki.png?raw=true

Screenshot of the project after this update:
<img width="800" height="824" alt="image" src="https://github.com/user-attachments/assets/7351e42e-e329-4824-b123-a31f00bc9700" />
