### PR TITLE
fix extra blank row issue

### DIFF
--- a/create_requirement_images.py
+++ b/create_requirement_images.py
@@ -227,8 +227,8 @@ def generate_requirement_image(
         for cur_file in project_files:
             # string for individual file
             if isinstance(cur_file, str):
-                if "." in cur_file[-5:]:
-                    cur_extension = cur_file.split(".")[-1]
+                if "." in cur_file:
+                    cur_extension = cur_file.rsplit(".", 1)[-1]
                     if cur_extension in SHOWN_FILETYPES:
                         project_files_to_draw.append(cur_file)
             # tuple for directory


### PR DESCRIPTION
resolves: #35 

The root cause of this was .license files. That file extension was added to the SHOWN_FILETYPES list a while back but some of the logic was hard-coded to check the last 5 characters in the filename to find the extension so it caused it to fail on extensions longer. The logic at different spots in the code being different caused it to leave room for .license files, but not actually render them. 

Here is an example of the fix.

Before: 
<img width="800" height="460" alt="image" src="https://github.com/user-attachments/assets/b7635053-a373-47e0-bee3-ddc9c2257d1d" />

After:
<img width="800" height="460" alt="_Adafruit_CircuitPython_Bundle_is31fl3741_is31fl3741_simpletest py" src="https://github.com/user-attachments/assets/52851c1c-a3c8-4e21-8435-b1860696579b" />
